### PR TITLE
url regex change to handle / url edge case

### DIFF
--- a/lib/githubhook.js
+++ b/lib/githubhook.js
@@ -26,7 +26,7 @@ var githubhook = exports.githubhook = function (port, sites, callback) {
     self.listener = http.createServer(function (req, res) {
         // Note that we manually track the body length in buflen, rather than trusting
         // the content-length header, this avoids crashes due to invalid headers
-        var id = req.url.match(/\/([\w_\-]+)/)[1],
+        var id = req.url.match(/\/([\w_\-]*)/)[1],
             bufs = [],
             buflen = 0,
             bufpos = 0,


### PR DESCRIPTION
the regex used to match the url was not working if the webhook was defined as / - changing from + (1 or more) to \* (zero or more) fixes this
