### PR TITLE
Check on "data.repository" and "data.repository.name" added

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,6 +64,10 @@ function serverHandler(req, res) {
             self.logger.error(Util.format('[GithubHook] received invalid data from %s, returning 400', remoteAddress));
             return reply(400, res);
         }
+        if (!data.repository || !data.repository.name) {
+            self.logger.error(Util.format('[GithubHook] received incomplete data from %s, returning 400', remoteAddress));
+            return reply(400, res);
+        }
 
         var event = req.headers['x-github-event'];
         var repo = data.repository.name;


### PR DESCRIPTION
The code took for granted that the JSON data received contained
a "repository" property. That is always the case when the request
originates from GitHub but that is not robust enough to resist the
World "Wild" Web.

The server crashed if the request did not contain that property
because the code attempted to access "data.repository.name". The
server now returns a 400 status code in that case.
