### PR TITLE
add custom prefix, refactor format and GithubHook string

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Available options are:
 * path: the path for the github callback, defaults to '/github/callback'
 * secret: if specified, you must use the same secret in your webhook configuration in github. if a secret is specified, but one is not configured in github, the hook will fail. if a secret is *not* specified, but one *is* configured in github, the signature will not be validated and will be assumed to be correct. consider yourself warned.
 * logger: an optional instance of a logger that supports the "log" and "error" methods and one parameter for data (like console), default is to not log. mostly only for debugging purposes.
+* prefix: an optional prefix function used to prefix log messages, default is `'[GithubHhook]'`. requires logger option to be set. useful if you want to prepend extra information, such as datestamp etc.
 
 License
 =======

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ var Url = require('url');
 var Querystring = require('querystring');
 var EventEmitter = require('events').EventEmitter;
 var Util = require('util');
+var format = Util.format;
 var Crypto = require('crypto');
 
 function reply(statusCode, res) {
@@ -65,7 +66,7 @@ function serverHandler(req, res) {
         }
 
 
-        self.logger.log(Util.format('[GithubHook] received %d bytes from %s', bufferLength, remoteAddress));
+        self.logger.log(format('received %d bytes from %s', bufferLength, remoteAddress));
 
         if (req.headers['content-type'] === 'application/x-www-form-urlencoded') {
             isForm = true;
@@ -78,7 +79,7 @@ function serverHandler(req, res) {
             var signature = req.headers['x-hub-signature'];
 
             if (!signature) {
-                self.logger.error('[GithubHook] secret configured, but missing signature, returning 403');
+                self.logger.error('secret configured, but missing signature, returning 403');
                 return reply(403, res);
             }
 
@@ -86,7 +87,7 @@ function serverHandler(req, res) {
             var digest = Crypto.createHmac('sha1', self.secret).update(data).digest('hex');
 
             if (signature !== digest) {
-                self.logger.error('[GithubHook] got invalid signature, returning 403');
+                self.logger.error('got invalid signature, returning 403');
                 return reply(403, res);
             }
         }
@@ -98,11 +99,11 @@ function serverHandler(req, res) {
 
         // invalid json
         if (!data) {
-            self.logger.error(Util.format('[GithubHook] received invalid data from %s, returning 400', remoteAddress));
+            self.logger.error(format('received invalid data from %s, returning 400', remoteAddress));
             return reply(400, res);
         }
         if (!data.repository || !data.repository.name) {
-            self.logger.error(Util.format('[GithubHook] received incomplete data from %s, returning 400', remoteAddress));
+            self.logger.error(format('received incomplete data from %s, returning 400', remoteAddress));
             return reply(400, res);
         }
 
@@ -111,7 +112,7 @@ function serverHandler(req, res) {
         var ref = data.ref;
 
         // and now we emit a bunch of data
-        self.logger.log(Util.format('[GithubHook] got %s event on %s:%s from %s', event, repo, ref, remoteAddress));
+        self.logger.log(format('got %s event on %s:%s from %s', event, repo, ref, remoteAddress));
         self.emit('*', event, repo, ref, data);
         self.emit(repo, event, ref, data);
         self.emit(repo + ':' + ref, event, data);
@@ -122,28 +123,34 @@ function serverHandler(req, res) {
         reply(200, res);
     });
 
-    self.logger.log(Util.format('[GithubHook]', req.method, req.url, remoteAddress));
+    self.logger.log(format(req.method, req.url, remoteAddress));
 
     // 404 if the path is wrong
     if (url.pathname !== self.path) {
-        self.logger.error(Util.format('[GithubHook] got invalid path from %s, returning 404', remoteAddress));
+        self.logger.error(format('got invalid path from %s, returning 404', remoteAddress));
         failed = true;
         return reply(404, res);
     }
 
     // 405 if the method is wrong
     if (req.method !== 'POST') {
-        self.logger.error(Util.format('[GithubHook] got invalid method from %s, returning 405', remoteAddress));
+        self.logger.error(format('got invalid method from %s, returning 405', remoteAddress));
         failed = true;
         return reply(405, res);
     }
 
     // 400 if it's not a github event
     if (!req.headers.hasOwnProperty('x-github-event')) {
-        self.logger.error(Util.format('[GithubHook] missing x-github-event header from %s, returning 400', remoteAddress));
+        self.logger.error(format('missing x-github-event header from %s, returning 400', remoteAddress));
         failed = true;
         return reply(400, res);
     }
+}
+
+function bindLogger(self, type) {
+  self.logger[type] = function (str) {
+    self._logger[type](self.logger.prefix() + ' ' + str);
+  };
 }
 
 var GithubHook = function (options) {
@@ -156,7 +163,13 @@ var GithubHook = function (options) {
     this.port = options.port || 3420;
     this.host = options.host || '0.0.0.0';
     this.secret = options.secret || false;
-    this.logger = options.logger || { log: function () {}, error: function () {} };
+
+    this._logger = options.logger || { log: function () {}, error: function () {} };
+    this.logger = {};
+    this.logger.prefix = options.prefix || function () { return '[GithubHook]'; };
+    bindLogger(this, 'log');
+    bindLogger(this, 'error');
+
     this.path = options.path || '/github/callback';
 
     this.server = Http.createServer(serverHandler.bind(this));
@@ -171,7 +184,7 @@ GithubHook.prototype.listen = function (callback) {
 
     self.server.listen(self.port, self.host, function () {
 
-        self.logger.log(Util.format('[GithubHook] listening for github events on %s:%d', self.host, self.port));
+        self.logger.log(format('listening for github events on %s:%d', self.host, self.port));
 
         if (typeof callback === 'function') {
             callback();


### PR DESCRIPTION
Allows me to do stuff like:

``` js
var githubhook = require('githubhook');
var format = require('util').format;
var github = githubhook({
  logger: console,
  prefix: function () {
    return format('[GithubHookkkk %s]', (new Date()).toISOString());
  }
});
```

```
[GithubHookkkk 2014-07-27T23:36:54.055Z] listening for github events on 0.0.0.0:3420
```
