### PR TITLE
Added command-line client for quick-and-easy hook-to-script setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ Available options are:
 Command-line
 -------------
 
+You can use the command-line client to execute a shell script when a particular 
+event occurs.
+
 Install it globally:
 
 ```bash
@@ -80,6 +83,12 @@ Options:
 ```
 
 Default values for options are same as for the API (see above).
+
+Example usage:
+
+```bash
+$ githubhook push:node-github-hook ./some_script.sh
+```
 
 
 License

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 node-github-hook
 ================
 
-This is a very simple, easy to use evented web hook for github.
+This is a very simple, easy to use evented web hook API for github. A command-line executable 
+is also available.
 
 To Install:
 -----------
@@ -48,6 +49,38 @@ Available options are:
 * path: the path for the github callback, defaults to '/github/callback'
 * secret: if specified, you must use the same secret in your webhook configuration in github. if a secret is specified, but one is not configured in github, the hook will fail. if a secret is *not* specified, but one *is* configured in github, the signature will not be validated and will be assumed to be correct. consider yourself warned.
 * logger: an optional instance of a logger that supports the "log" and "error" methods and one parameter for data (like console), default is to not log. mostly only for debugging purposes.
+
+
+Command-line
+-------------
+
+Install it globally:
+
+```bash
+$ npm install -g node-github-hook
+```
+
+Then you can run `githubhook`:
+
+```bash
+$ githubhook --help
+
+Usage:
+  githubhook [--host=HOST] [--port=PORT] [--callback=URL_PATH] [--secret=SECRET] [--verbose] <trigger> <script>
+
+Options:
+
+  --host=HOST             Address to listen on
+  --port=PORT             Port to listen on
+  --callback=URL_PATH     The callback URL path
+  --secret=SECRET         The secret you use the in the Github webhook config
+  --verbose               Log to console
+  --version               Output the version number
+  -h, --help              Output usage information
+```
+
+Default values for options are same as for the API (see above).
+
 
 License
 =======

--- a/bin/githubhook
+++ b/bin/githubhook
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+
+var child_process = require('child_process'),
+  docopt = require('docopt'),
+  multiline = require('multiline'),
+  path = require('path');
+
+var githubhook = require('../');
+
+
+var doc = multiline(function() {/*
+
+Usage:
+  githubhook [--host=HOST] [--port=PORT] [--callback=URL_PATH] [--secret=SECRET] [--verbose] <trigger> <script>
+
+Options:
+
+  --host=HOST             Address to listen on
+  --port=PORT             Port to listen on
+  --callback=URL_PATH     The callback URL path
+  --secret=SECRET         The secret you use the in the Github webhook config
+  --verbose                 Log to console
+  --version                 Output the version number
+  -h, --help                Output usage information
+
+*/});
+
+
+var options = docopt.docopt(doc, {
+  version: require('../package.json').version,
+  help: true,
+  options_first: false,
+  exit: true
+});
+
+
+var github = githubhook({
+  host: options['--host'],
+  port: options['--port'] ? parseInt(options['--port']) : null,
+  path: options['--callback'],
+  secret: options['--secret'],
+  logger: options['--verbose'] ? console : null,
+});
+
+// start it!
+github.listen();
+
+// trigger
+github.on(options['<trigger>'], function () {
+  var scriptPath = path.resolve(options['<script>']);
+
+  child_process.execFile(scriptPath, function(err, stdout, stderr) {
+    if (options['--verbose']) {
+      console.log('--> EXEC ' + scriptPath);
+
+      if (err) {
+        console.error(err.stack);
+      } else {
+        console.error(stderr);
+        console.log(stdout);
+      }
+
+      console.log('--- END ' + scriptPath);
+    }
+  });
+});
+

--- a/package.json
+++ b/package.json
@@ -8,5 +8,9 @@
   "devDependencies": {
     "jshint": "^2.5.1",
     "precommit-hook": "^1.0.2"
+  },
+  "dependencies": {
+    "docopt": "^0.6.2",
+    "multiline": "^1.0.2"
   }
 }


### PR DESCRIPTION
Added a command-line executable (`githubhook`) so that you can quickly setup a script to be executed for a particular trigger.