### PR TITLE
Fix missing executable script reference

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,5 +12,8 @@
   "dependencies": {
     "docopt": "^0.6.2",
     "multiline": "^1.0.2"
+  },
+  "bin": {
+    "githubhook": "./bin/githubhook"
   }
 }


### PR DESCRIPTION
Had forgotten to add a reference to the `githubhook` executable in package.json in #18 