### PR TITLE
Fix wrong node package name in global install

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ event occurs.
 Install it globally:
 
 ```bash
-$ npm install -g node-github-hook
+$ npm install -g githubhook
 ```
 
 Then you can run `githubhook`:


### PR DESCRIPTION
The package name mentioned in the README is `node-github-hook` which will give package not found error on npm. It should be `githubhook`.