### PR TITLE
Fixed so that node-github-hook runs under iisnode

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ function serverHandler(req, res) {
     var bufferLength = 0;
     var isForm = false;
     var failed = false;
-    var remoteAddress = req.ip || req.socket.remoteAddress || req.socket.socket.remoteAddress;
+    var remoteAddress = req.headers['x-forwarded-for'] || req.ip || req.socket.remoteAddress || req.socket.socket.remoteAddress;
 
     req.on('data', function (chunk) {
 


### PR DESCRIPTION
Broke since iisnode is not able to resolve remoteAddress. See https://github.com/tjanczuk/iisnode/issues/94 for more information