### PR TITLE
use spawn to avoid delays and maxBuffer errors with verbose output

### DIFF
--- a/bin/githubhook
+++ b/bin/githubhook
@@ -58,20 +58,21 @@ github.listen();
 
 // trigger
 github.on(options['<trigger>'], function () {
-  var scriptPath = path.resolve(options['<script>']);
-
-  child_process.execFile(scriptPath, function(err, stdout, stderr) {
-    if (options['--verbose']) {
-      console.log('--> EXEC ' + scriptPath);
-
-      if (err) {
-        console.error(err.stack);
-      } else {
-        console.error(stderr);
-        console.log(stdout);
-      }
-
+  var scriptPath = path.resolve(options['<script>']),
+      spawnOptions = {},
+      verbose = options['--verbose'],
+      child;
+  if (verbose) {
+    console.log('--> EXEC ' + scriptPath);
+    spawnOptions.stdio = 'inherit';
+  }
+  child = child_process.spawn(scriptPath, spawnOptions);
+  if (verbose) {
+    child.on('error', function (err) {
+      console.error(err.stack);
+    });
+    child.on('close', function () {
       console.log('--- END ' + scriptPath);
-    }
-  });
+    });
+  }
 });


### PR DESCRIPTION
This change avoids two problems:

1. If the output isn't streamed, the maxBuffer limit can be reached, causing a crash.
2. Without streaming, no output appears until the process is over. For something like a build that can be a significant delay and make it hard to monitor a log with `tail -f`, for example.