### PR TITLE
honor github ping request

### DIFF
--- a/index.js
+++ b/index.js
@@ -120,6 +120,9 @@ function serverHandler(req, res) {
             data.request = req;
             var event = req.headers['x-github-event'] || req.headers['x-gogs-event'] || req.headers['x-event-key'] || (req.headers['x-gitlab-event'] ? req.headers['x-gitlab-event'].split(' ')[0].toLowerCase() : 'unknown');
 
+	    if (event === 'ping') {
+		self.emit(event, null, null, data);
+	    } else
             // handle GitLab system hook
             if (event !== 'system'){
                 // invalid json


### PR DESCRIPTION
I noticed that github issues a ping request when setting up the webhook.
When a  node-github-hook instance is already running, the request fails with an 400 error code when a  as there are no repository object in data.

I added this trivial workaround to make initial setup more satisfying :)